### PR TITLE
Add rename function

### DIFF
--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -58,6 +58,16 @@ class MX_CORE_API Node : public InterfaceElement
     }
     virtual ~Node() { }
 
+    /// @name Name
+    /// @{
+
+    /// Set the element's name string.  The name of a MaterialX element must be
+    /// unique among all elements at the same scope. Optionally updates downstream ports.
+    /// @throws Exception if an element at the same scope already possesses the
+    ///    given name.
+    void setName(const std::string& name, bool updateReferences = false);
+
+    /// @}
     /// @name Connections
     /// @{
 
@@ -327,6 +337,13 @@ class MX_CORE_API NodeGraph : public GraphElement
     }
     virtual ~NodeGraph() { }
 
+    /// Set the element's name string.  The name of a MaterialX element must be
+    /// unique among all elements at the same scope. Optionally updates downstream ports.
+    /// @throws Exception if an element at the same scope already possesses the
+    ///    given name.
+    void setName(const std::string& name, bool updateReferences = false);
+
+    /// @}
     /// @name Material References
     /// @{
 
@@ -495,14 +512,6 @@ class MX_CORE_API Backdrop : public Element
     static const string WIDTH_ATTRIBUTE;
     static const string HEIGHT_ATTRIBUTE;
 };
-
-/// Renames an element and optionally updates downstream port references. If updateReferences
-/// is false this behaves exactly like Element::setName for all types. Downstream ports are only
-/// considered if given element is of type Node/NodeGraph.
-/// @param element           The element to rename.
-/// @param newName           The desired new name; will be sanitized to a valid child name.
-/// @param updateReferences  If true, update downstream port references; otherwise only rename.
-MX_CORE_API void renameElement(ElementPtr element, const std::string& newName, bool updateReferences = false);
 
 MATERIALX_NAMESPACE_END
 

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -496,11 +496,13 @@ class MX_CORE_API Backdrop : public Element
     static const string HEIGHT_ATTRIBUTE;
 };
 
-/// Set the element's name string.  The name of a MaterialX element must be
-/// unique among all elements at the same scope.
-/// @throws Exception if an element at the same scope already possesses the
-///    given name. // TODO ratil
-MX_CORE_API void renameElement(ElementPtr element, const std::string& newName, bool updateReferences=false);
+/// Renames an element and optionally updates downstream port references. If updateReferences
+/// is false this behaves exactly like Element::setName for all types. Downstream ports are only
+/// considered if given element is of type Node/NodeGraph.
+/// @param element           The element to rename.
+/// @param newName           The desired new name; will be sanitized to a valid child name.
+/// @param updateReferences  If true, update downstream port references; otherwise only rename.
+MX_CORE_API void renameElement(ElementPtr element, const std::string& newName, bool updateReferences = false);
 
 MATERIALX_NAMESPACE_END
 

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -496,6 +496,12 @@ class MX_CORE_API Backdrop : public Element
     static const string HEIGHT_ATTRIBUTE;
 };
 
+/// Set the element's name string.  The name of a MaterialX element must be
+/// unique among all elements at the same scope.
+/// @throws Exception if an element at the same scope already possesses the
+///    given name. // TODO ratil
+MX_CORE_API void renameElement(ElementPtr element, const std::string& newName, bool updateReferences=false);
+
 MATERIALX_NAMESPACE_END
 
 #endif

--- a/source/MaterialXTest/MaterialXCore/Node.cpp
+++ b/source/MaterialXTest/MaterialXCore/Node.cpp
@@ -774,6 +774,133 @@ TEST_CASE("Node Definition Creation", "[nodedef]")
 
         doc->removeChild(graph->getName());
     }
-    
+
     REQUIRE(doc->validate());
+}
+
+TEST_CASE("renameElement", "[Node, Node Graph]")
+{
+    mx::DocumentPtr doc = mx::createDocument();
+
+    const std::string type = "float";
+    const std::string new_name = "new_name";
+    SECTION("Node")
+    {
+        // Upstream -> Downstream
+        SECTION("Node within NodeGraph -> NodeGraph output")
+        {
+            mx::NodeGraphPtr parentGraph = doc->addNodeGraph();
+
+            mx::NodePtr upstreamNode = parentGraph->addNode("constant", "upstreamNode", type);
+            upstreamNode->addOutput("output", type);
+
+            mx::PortElementPtr downstreamOutput = parentGraph->addOutput("out", type);
+            downstreamOutput->setNodeName(upstreamNode->getName());
+
+            REQUIRE(doc->validate());
+            renameElement(upstreamNode, new_name, true);
+            REQUIRE(upstreamNode->getName() == new_name);
+            REQUIRE(downstreamOutput->getNodeName() == new_name);
+        }
+        SECTION("Free node")
+        {
+            SECTION("Free Node -> Free Node")
+            {
+                mx::NodePtr upstreamNode = doc->addNode("constant", "upstreamNode", type);
+                upstreamNode->addOutput("output", type);
+
+                mx::NodePtr downStreamNode = doc->addNode("downStreamNode");
+                mx::InputPtr downstreamInput = downStreamNode->addInput("in", type);
+                downstreamInput->setNodeName(upstreamNode->getName());
+
+                REQUIRE(doc->validate());
+                renameElement(upstreamNode, new_name, true);
+                REQUIRE(upstreamNode->getName() == new_name);
+                REQUIRE(downstreamInput->getNodeName() == new_name);
+            }
+            SECTION("Free Node -> NodeGraph input")
+            {
+                mx::NodePtr upstreamNode = doc->addNode("constant", "upstreamNode", type);
+                upstreamNode->addOutput("output", type);
+
+                mx::NodeGraphPtr downstreamGraph = doc->addNodeGraph();
+                mx::InputPtr downstreamInput = downstreamGraph->addInput("input", type);
+                downstreamInput->setNodeName(upstreamNode->getName());
+
+                REQUIRE(doc->validate());
+                renameElement(upstreamNode, new_name, true);
+                REQUIRE(upstreamNode->getName() == new_name);
+                REQUIRE(downstreamInput->getNodeName() == new_name);
+            }
+        }
+        SECTION("Node -> NodeDef output")
+        {
+            mx::NodeGraphPtr compoundNodeGraph = doc->addNodeGraph();
+            mx::OutputPtr compoundNodeGraphOutput = compoundNodeGraph->addOutput("output", type);
+
+            mx::NodePtr compoundNodeGraphNode = compoundNodeGraph->addNode("constant", "upstreamNode", type);
+            compoundNodeGraphNode->addOutput("output", type);
+            compoundNodeGraphOutput->setNodeName(compoundNodeGraphNode->getName());
+
+            std::string newNodeDefName = doc->createValidChildName("ND_" + compoundNodeGraph->getName());
+            std::string newGraphName = doc->createValidChildName("NG_" + compoundNodeGraph->getName());
+            mx::NodeDefPtr nodeDef = doc->addNodeDefFromGraph(compoundNodeGraph, newNodeDefName, "NODENAME", newGraphName);
+            mx::NodeGraphPtr functionalNodeGraph = nodeDef->getImplementation()->asA<mx::NodeGraph>();
+
+            mx::NodePtr upstreamNode = functionalNodeGraph->getChild(compoundNodeGraphNode->getName())->asA<mx::Node>();
+            REQUIRE(upstreamNode);
+
+            mx::OutputPtr downstreamOutput = functionalNodeGraph->getOutput(compoundNodeGraphOutput->getName());
+            REQUIRE(downstreamOutput);
+
+            REQUIRE(doc->validate());
+            renameElement(upstreamNode, new_name, true);
+            REQUIRE(upstreamNode->getName() == new_name);
+            REQUIRE(downstreamOutput->getNodeName() == new_name);
+        }
+    }
+    SECTION("Node Graph")
+    {
+        mx::NodeGraphPtr upstreamGraph = doc->addNodeGraph();
+        mx::NodePtr upstreamGraphNode = upstreamGraph->addNode("constant", "upstreamNode", type);
+        mx::OutputPtr upstreamGraphOutput = upstreamGraph->addOutput("output", type);
+        upstreamGraphOutput->setNodeName(upstreamGraphNode->getName());
+
+        SECTION("Node Graph -> Node")
+        {
+            mx::NodePtr downstreamNode = doc->addNode("constant", "downstreamNode", type);
+            mx::InputPtr downstreamInput = downstreamNode->addInput("input", type);
+            downstreamInput->setNodeGraphString(upstreamGraph->getName());
+            downstreamInput->setOutputString(upstreamGraphOutput->getName());
+
+            std::string message;
+            doc->validate(&message);
+            REQUIRE(message.empty());
+            renameElement(upstreamGraph, new_name, true);
+            REQUIRE(upstreamGraph->getName() == new_name);
+            REQUIRE(downstreamInput->getNodeGraphString() == new_name);
+        }
+        SECTION("Node Graph -> Node Graph")
+        {
+            mx::NodeGraphPtr downstreamGraph = doc->addNodeGraph();
+            mx::InputPtr downstreamInput = downstreamGraph->addInput("input", type);
+            downstreamInput->setNodeGraphString(upstreamGraph->getName());
+            downstreamInput->setOutputString(upstreamGraphOutput->getName());
+
+            REQUIRE(doc->validate());
+            renameElement(upstreamGraph, new_name, true);
+            REQUIRE(upstreamGraph->getName() == new_name);
+            REQUIRE(downstreamInput->getNodeGraphString() == new_name);
+        }
+    }
+}
+
+TEST_CASE("renameElement", "[Element]")
+{
+    mx::DocumentPtr doc = mx::createDocument();
+    mx::ElementPtr child = doc->addMaterialNode("name1");
+    const std::string new_name = "new_name";
+    renameElement(child, new_name, true);
+    REQUIRE(doc->validate());
+    REQUIRE(child->getName() == new_name);
 }

--- a/source/MaterialXTest/MaterialXCore/Node.cpp
+++ b/source/MaterialXTest/MaterialXCore/Node.cpp
@@ -778,13 +778,13 @@ TEST_CASE("Node Definition Creation", "[nodedef]")
     REQUIRE(doc->validate());
 }
 
-TEST_CASE("renameElement with connections", "[Node, Node Graph]")
+TEST_CASE("renameElement with connections", "[node, nodegraph]")
 {
     mx::DocumentPtr doc = mx::createDocument();
 
     const std::string type = "float";
     const std::string new_name = "new_name";
-    SECTION("Node")
+    SECTION("node")
     {
         // Upstream -> Downstream
         SECTION("Node within NodeGraph -> NodeGraph output")
@@ -863,7 +863,7 @@ TEST_CASE("renameElement with connections", "[Node, Node Graph]")
             REQUIRE(downstreamOutput->getNodeName() == new_name);
         }
     }
-    SECTION("Node Graph")
+    SECTION("nodegraph")
     {
         mx::NodeGraphPtr upstreamGraph = doc->addNodeGraph();
         mx::NodePtr upstreamGraphNode = upstreamGraph->addNode("constant", "upstreamNode", type);
@@ -895,7 +895,7 @@ TEST_CASE("renameElement with connections", "[Node, Node Graph]")
     }
 }
 
-TEST_CASE("renameElement with no connections", "[Element]")
+TEST_CASE("renameElement with no connections", "[element, document]")
 {
     mx::DocumentPtr doc = mx::createDocument();
     mx::ElementPtr child = doc->addMaterialNode("name1");

--- a/source/MaterialXTest/MaterialXCore/Node.cpp
+++ b/source/MaterialXTest/MaterialXCore/Node.cpp
@@ -797,7 +797,7 @@ TEST_CASE("renameElement with connections", "[node, nodegraph]")
             mx::PortElementPtr downstreamOutput = parentGraph->addOutput("out", type);
             downstreamOutput->setNodeName(upstreamNode->getName());
 
-            renameElement(upstreamNode, new_name, true);
+            upstreamNode->setName(new_name, true);
             REQUIRE(upstreamNode->getName() == new_name);
             REQUIRE(downstreamOutput->getNodeName() == new_name);
         }
@@ -813,13 +813,13 @@ TEST_CASE("renameElement with connections", "[node, nodegraph]")
                 downstreamInput->setNodeName(upstreamNode->getName());
                 SECTION("Update references")
                 {
-                    renameElement(upstreamNode, new_name, true);
+                    upstreamNode->setName(new_name, true);
                     REQUIRE(upstreamNode->getName() == new_name);
                     REQUIRE(downstreamInput->getNodeName() == new_name);
                 }
                 SECTION("Do not update references")
                 {
-                    renameElement(upstreamNode, new_name, false);
+                    upstreamNode->setName(new_name, false);
                     REQUIRE(upstreamNode->getName() == new_name);
                     REQUIRE(downstreamInput->getNodeName() != new_name);
                 }
@@ -833,7 +833,7 @@ TEST_CASE("renameElement with connections", "[node, nodegraph]")
                 mx::InputPtr downstreamInput = downstreamGraph->addInput("input", type);
                 downstreamInput->setNodeName(upstreamNode->getName());
 
-                renameElement(upstreamNode, new_name, true);
+                upstreamNode->setName(new_name, true);
                 REQUIRE(upstreamNode->getName() == new_name);
                 REQUIRE(downstreamInput->getNodeName() == new_name);
             }
@@ -858,7 +858,7 @@ TEST_CASE("renameElement with connections", "[node, nodegraph]")
             mx::OutputPtr downstreamOutput = functionalNodeGraph->getOutput(compoundNodeGraphOutput->getName());
             REQUIRE(downstreamOutput);
 
-            renameElement(upstreamNode, new_name, true);
+            upstreamNode->setName(new_name, true);
             REQUIRE(upstreamNode->getName() == new_name);
             REQUIRE(downstreamOutput->getNodeName() == new_name);
         }
@@ -877,7 +877,7 @@ TEST_CASE("renameElement with connections", "[node, nodegraph]")
             downstreamInput->setNodeGraphString(upstreamGraph->getName());
             downstreamInput->setOutputString(upstreamGraphOutput->getName());
 
-            renameElement(upstreamGraph, new_name, true);
+            upstreamGraph->setName(new_name, true);
             REQUIRE(upstreamGraph->getName() == new_name);
             REQUIRE(downstreamInput->getNodeGraphString() == new_name);
         }
@@ -888,22 +888,9 @@ TEST_CASE("renameElement with connections", "[node, nodegraph]")
             downstreamInput->setNodeGraphString(upstreamGraph->getName());
             downstreamInput->setOutputString(upstreamGraphOutput->getName());
 
-            renameElement(upstreamGraph, new_name, true);
+            upstreamGraph->setName(new_name, true);
             REQUIRE(upstreamGraph->getName() == new_name);
             REQUIRE(downstreamInput->getNodeGraphString() == new_name);
         }
     }
-}
-
-TEST_CASE("renameElement with no connections", "[element, document]")
-{
-    mx::DocumentPtr doc = mx::createDocument();
-    mx::ElementPtr child = doc->addMaterialNode("name1");
-    const std::string new_name = "new_name";
-    renameElement(child, new_name, true);
-    REQUIRE(doc->validate());
-    REQUIRE(child->getName() == new_name);
-
-    renameElement(doc, new_name, true);
-    REQUIRE(doc->getName() == new_name);
 }


### PR DESCRIPTION
This commit adds the `setName` method on `Node` and `NodeGraph`.
- When `updateReferences == false`, behave exactly like the original `setName()`.  
- When `updateReferences == true`, also walk downstream ports or inputs and updates corresponding node or nodegraph name.

 **API added**
  ```cpp
  void Node::setName(const std::string& newName, bool updateReferences);
  void NodeGraph::setName(const std::string& newName, bool updateReferences);