### PR TITLE
Apply weight to the entire subsurface_bssdrf closure

### DIFF
--- a/libraries/pbrlib/genosl/mx_subsurface_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_subsurface_bsdf.osl
@@ -1,8 +1,8 @@
 void mx_subsurface_bsdf(float weight, color albedo, color radius, float anisotropy, normal N, output BSDF bsdf)
 {
 #if OSL_VERSION_MAJOR >= 1 && OSL_VERSION_MINOR >= 14
-    bsdf = subsurface_bssrdf(N, weight * albedo, radius, anisotropy);
+    bsdf = weight * subsurface_bssrdf(N, albedo, radius, anisotropy);
 #else
-    bsdf = subsurface_bssrdf(N, weight * albedo, 1.0, radius, anisotropy);
+    bsdf = weight* subsurface_bssrdf(N, albedo, 1.0, radius, anisotropy);
 #endif
 }

--- a/libraries/pbrlib/genosl/mx_subsurface_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_subsurface_bsdf.osl
@@ -3,6 +3,6 @@ void mx_subsurface_bsdf(float weight, color albedo, color radius, float anisotro
 #if OSL_VERSION_MAJOR >= 1 && OSL_VERSION_MINOR >= 14
     bsdf = weight * subsurface_bssrdf(N, albedo, radius, anisotropy);
 #else
-    bsdf = weight* subsurface_bssrdf(N, albedo, 1.0, radius, anisotropy);
+    bsdf = weight * subsurface_bssrdf(N, albedo, 1.0, radius, anisotropy);
 #endif
 }


### PR DESCRIPTION
In a Slack [discussion](https://academysoftwarefdn.slack.com/archives/CV11J5AAF/p1738113173157079), a question was raised regarding the weight application in subsurface scattering for MaterialX. Rickard Sirefelt pointed out that the weight multiplier was applied directly to the albedo input rather than the entire subsurface scattering function, questioning if this was the intended approach. It was suggested that the weight multiplier might have been incorrectly placed and should potentially apply to the entire subsurface function instead, signaling a possible oversight in the current implementation. This PR moves the weight multiplier to apply to the entire closure.

Before this PR
`bsdf = subsurface_bssrdf(N, weight * albedo, radius, anisotropy);`

After this PR
`bsdf = weight * subsurface_bssrdf(N, albedo, radius, anisotropy);`


